### PR TITLE
Adds submit position check to art mapper(Fixes the entire script)

### DIFF
--- a/ArtMapper2.py
+++ b/ArtMapper2.py
@@ -29,6 +29,7 @@ image_selected = False
 spraycolor_pos = None
 # Position of the hex input area in the color picker
 hexput_pos  = None
+submit_pos = None
 # Position of the canvas on the screen
 topleft_pos = None
 bottomright_pos = None
@@ -238,6 +239,17 @@ def get_spraycolor():
 def get_spraycolor_mouse():
     override_next_click(spraycolor_callback)
 
+def submit_callback(newpos):
+    global submit_pos
+    submit_pos = newpos
+    submit_desc.config(text=f"Submit Menu Pos: {submit_pos}", fg="green")
+    
+def get_submit():
+    create_draggable_window(submit_callback)
+    
+def get_submit_mouse():
+    override_next_click(submit_callback)
+    
 # Hex input pos
 def hexput_callback(newpos):
     global hexput_pos
@@ -439,12 +451,18 @@ def start_mapping(continueprogress = False):
         pyperclip.copy(str(color))
         root.after(TRANSRATE)
         pyautogui.click(spraycolor_pos)
+        print(spraycolor_pos)
         root.after(TRANSRATE)
         pyautogui.doubleClick(hexput_pos)
         root.after(TRANSRATE)
         pyautogui.hotkey("ctrlleft", "v")
         root.after(TRANSRATE)
         pyautogui.hotkey("enter")
+        root.after(TRANSRATE)
+        pyautogui.click(submit_pos)
+        root.after(TRANSRATE)
+        pyautogui.click(spraycolor_pos)
+        root.after(TRANSRATE)
 
         return True
     def handle_painting():
@@ -731,6 +749,24 @@ get_spraycolor_button.grid(row=0, column=0, padx=5, sticky="ew")
 
 get_spraycolor_button_mouse = tk.Button(spraycolor_button_frame, text="Mouse", command=get_spraycolor_mouse, bg="#444444", fg="#ffffff")
 get_spraycolor_button_mouse.grid(row=0, column=1, padx=5, sticky="ew")
+
+# Input for submit button
+submit_desc = tk.Label(frame_3, text="Submit Button Not Set", font=("Franklin Gothic Medium", 10), fg="red", bg="#1e1e1e")
+submit_desc.pack()
+
+submit_setvia = tk.Label(frame_3, text="Set Location Via:", fg="white", bg="#1e1e1e")
+submit_setvia.pack()
+
+submit_button_frame = tk.Frame(frame_3, bg="#1e1e1e")
+submit_button_frame.pack(fill=tk.X, padx=5, pady=5)
+submit_button_frame.grid_columnconfigure(0, weight=1, uniform="group")
+submit_button_frame.grid_columnconfigure(1, weight=1, uniform="group")
+
+get_submit_button = tk.Button(submit_button_frame, text="Window", command=get_submit, bg="#444444", fg="#ffffff")
+get_submit_button.grid(row=0, column=0, padx=5, sticky="ew")
+
+get_submit_button_mouse = tk.Button(submit_button_frame, text="Mouse", command=get_submit_mouse, bg="#444444", fg="#ffffff")
+get_submit_button_mouse.grid(row=0, column=1, padx=5, sticky="ew")
 
 # Input for hexput
 hexput_desc = tk.Label(frame_3, text="Hex Input Field Not Set", font=("Franklin Gothic Medium", 10), fg="red", bg="#1e1e1e")


### PR DESCRIPTION
Closes #2 

As we all know, the UI for the color picker was recently changed in tg downstreams, starting in monkestation. (thank you Absolucy)
![305763689-723e2382-3964-4ad3-8a16-01fc7e7610d7](https://github.com/user-attachments/assets/829f2439-c95b-4d00-ad8c-1ad23348f516)

So there had to be an additional position checker for the submit button that updates the current color.

## CURRENT PROBLEMS:
**The color picker window CANNOT be moved when you select the positions of the hex prompt and submit button, otherwise the script will not function properly!**

Every time the color picker window is opened through using palette in hand, the window that spawns is centered. There is unfortunately, no way around this currently.



I had a friend of mine test this tool on monkestation which lead to this lovely lovely altercation.

<img width="1214" height="567" alt="image" src="https://github.com/user-attachments/assets/93ef8b6b-76ec-433a-986a-74c36bd2805b" />

(NOTE: Spray can usage remains untested.)